### PR TITLE
refactor(package-manager): abstract the package manager methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 0,
     'default-case': 0,
     'import/prefer-default-export': 0,
-    'no-lonely-if': 0
+    'no-lonely-if': 0,
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editor specific
+.idea
+
 # Logs
 logs
 *.log

--- a/src/classes/package_manager.ts
+++ b/src/classes/package_manager.ts
@@ -48,7 +48,7 @@ class PackageManager {
       stdio: goWithDefault ? 'ignore' : 'inherit',
     });
 
-    packageSpinner.succeed(`🔨 Initialized The Package with ${pkgManager}`);
+    packageSpinner.succeed(`🔨 Initialized The Package with ${pkgManager.type}`);
   }
 
   static createScripts(

--- a/src/classes/project_generator.ts
+++ b/src/classes/project_generator.ts
@@ -148,7 +148,7 @@ class ProjectGenerator {
 
     console.log(chalk.greenBright('🎉 Ready!'));
     console.log(
-      chalk.greenBright(`🚀 cd ${projectName} && ${packageManager.type} start`)
+      chalk.greenBright(`🚀 cd ${projectName} && ${pkgManagerName} start`)
     );
 
     if (extraOptions!.includes('git')) {

--- a/src/config/dependencies.ts
+++ b/src/config/dependencies.ts
@@ -1,4 +1,4 @@
-export const tsDependencies = 'typescript ts-node @types/node -D';
+export const tsDependencies = 'typescript ts-node @types/node';
 
 export const eslintDependencies =
   'eslint eslint-config-node eslint-plugin-node';

--- a/src/config/eslint/airbnb/index.airbnb.ts
+++ b/src/config/eslint/airbnb/index.airbnb.ts
@@ -4,8 +4,9 @@ import esAirBnbTs from './eslint_airbnb_ts';
 import esAirBnbBabelPretty from './eslint_airbnb_prettier_babel';
 import esAirBnbJsPretty from './eslint_airbnb_prettier_js';
 import esAirBnbTsPretty from './eslint_airbnb_prettier_ts';
+import { ESLintSpecificConfig } from '../index.eslint';
 
-export const airBnb = {
+export const airBnb: ESLintSpecificConfig = {
   js: esAirBnbJs,
   ts: esAirBnbTs,
   babel: esAirBnbBabel,

--- a/src/config/eslint/google/index.google.ts
+++ b/src/config/eslint/google/index.google.ts
@@ -4,8 +4,9 @@ import esGoogleTs from './eslint_google_ts';
 import esGoogleBabelPretty from './eslint_google_prettier_babel';
 import esGoogleJsPretty from './eslint_google_prettier_js';
 import esGoogleTsPretty from './eslint_google_prettier_ts';
+import { ESLintSpecificConfig } from '../index.eslint';
 
-export const google = {
+export const google: ESLintSpecificConfig = {
   js: esGoogleJs,
   ts: esGoogleTs,
   babel: esGoogleBabel,

--- a/src/config/eslint/index.eslint.ts
+++ b/src/config/eslint/index.eslint.ts
@@ -8,7 +8,20 @@ import { airBnb } from './airbnb/index.airbnb';
 import { google } from './google/index.google';
 import { standard } from './standard/index.standard';
 
-const esLint = {
+export interface ESLintSpecificConfig {
+  js: unknown;
+  ts: unknown;
+  babel: unknown;
+  tsPretty: unknown;
+  jsPretty: unknown;
+  babelPretty: unknown;
+}
+
+const esLint: ESLintSpecificConfig & {
+  airBnb: ESLintSpecificConfig;
+  google: ESLintSpecificConfig;
+  standard: ESLintSpecificConfig;
+} = {
   airBnb,
   google,
   standard,

--- a/src/config/eslint/standard/index.standard.ts
+++ b/src/config/eslint/standard/index.standard.ts
@@ -4,8 +4,9 @@ import esStandardTs from './eslint_standard_ts';
 import esStandardBabelPretty from './eslint_standard_prettier_babel';
 import esStandardJsPretty from './eslint_standard_prettier_js';
 import esStandardTsPretty from './eslint_standard_prettier_ts';
+import { ESLintSpecificConfig } from '../index.eslint';
 
-export const standard = {
+export const standard: ESLintSpecificConfig = {
   js: esStandardJs,
   ts: esStandardTs,
   babel: esStandardBabel,

--- a/src/package_managers/base.ts
+++ b/src/package_managers/base.ts
@@ -1,0 +1,30 @@
+import { StdioOptions } from 'child_process';
+
+export enum PackageInstallationType {
+  DEPENDENCIES = '',
+  DEV_DEPENDENCIES = '',
+  OPTIONAL = '',
+  BUNDLED = '',
+}
+
+export type PackageManagerInit = ({
+  cwd,
+  interactive,
+  stdio,
+}: {
+  cwd: string;
+  interactive: boolean;
+  stdio: StdioOptions;
+}) => Promise<void>;
+
+export type PackageManagerInstall = ({
+  cwd,
+  packageName,
+  type,
+  stdio,
+}: {
+  cwd: string;
+  packageName: boolean;
+  type: PackageInstallationType;
+  stdio: StdioOptions;
+}) => Promise<void>;

--- a/src/package_managers/base.ts
+++ b/src/package_managers/base.ts
@@ -1,10 +1,10 @@
 import { StdioOptions } from 'child_process';
+import { PackageManagerType } from './package_manager_type';
 
 export enum PackageInstallationType {
-  DEPENDENCIES = '',
-  DEV_DEPENDENCIES = '',
-  OPTIONAL = '',
-  BUNDLED = '',
+  DEPENDENCIES,
+  DEV_DEPENDENCIES,
+  OPTIONAL,
 }
 
 export type PackageManagerInit = ({
@@ -15,7 +15,7 @@ export type PackageManagerInit = ({
   cwd: string;
   interactive: boolean;
   stdio: StdioOptions;
-}) => Promise<void>;
+}) => Buffer;
 
 export type PackageManagerInstall = ({
   cwd,
@@ -24,7 +24,13 @@ export type PackageManagerInstall = ({
   stdio,
 }: {
   cwd: string;
-  packageName: boolean;
+  packageName: string;
   type: PackageInstallationType;
   stdio: StdioOptions;
-}) => Promise<void>;
+}) => Buffer;
+
+export default interface IPackageManager {
+  type: PackageManagerType;
+  init: PackageManagerInit;
+  install: PackageManagerInstall;
+}

--- a/src/package_managers/factory.ts
+++ b/src/package_managers/factory.ts
@@ -1,0 +1,21 @@
+import * as BasePackageManager from './base';
+
+import * as NPM from './npm';
+import * as YARN from './yarn';
+
+
+export enum PackageManagerType {
+    NPM = '';
+    YARN = '';
+}
+
+export const factory = (packageManagerType: PackageManagerType): typeof BasePackageManager  => {
+    switch (packageManagerType) {
+        case PackageManagerType.NPM:
+            return NPM;
+        case PackageManagerType.YARN:
+            return YARN;
+    }
+};
+
+export BasePackageManager;

--- a/src/package_managers/factory.ts
+++ b/src/package_managers/factory.ts
@@ -1,21 +1,18 @@
-import * as BasePackageManager from './base';
+import BasePackageManager from './base';
 
-import * as NPM from './npm';
-import * as YARN from './yarn';
+import { PackageManagerType } from './package_manager_type';
+import NPM from './npm';
+import YARN from './yarn';
 
-
-export enum PackageManagerType {
-    NPM = '';
-    YARN = '';
-}
-
-export const factory = (packageManagerType: PackageManagerType): typeof BasePackageManager  => {
-    switch (packageManagerType) {
-        case PackageManagerType.NPM:
-            return NPM;
-        case PackageManagerType.YARN:
-            return YARN;
-    }
+export const factory = (
+  packageManagerType: PackageManagerType | string
+): BasePackageManager => {
+  switch (packageManagerType) {
+    case 'npm':
+      return NPM;
+    case 'yarn':
+      return YARN;
+    default:
+      throw new Error(`Invalid package manager type ${packageManagerType}`);
+  }
 };
-
-export BasePackageManager;

--- a/src/package_managers/index.ts
+++ b/src/package_managers/index.ts
@@ -1,0 +1,3 @@
+export { factory } from './factory';
+
+export { default as IPackageManager } from './base';

--- a/src/package_managers/index.ts
+++ b/src/package_managers/index.ts
@@ -1,3 +1,2 @@
 export { factory } from './factory';
-
 export { default as IPackageManager } from './base';

--- a/src/package_managers/npm.ts
+++ b/src/package_managers/npm.ts
@@ -1,0 +1,49 @@
+import { exec } from 'child_process';
+import {
+  PackageInstallationType,
+  PackageManagerInit,
+  PackageManagerInstall,
+} from './base';
+
+export const init: PackageManagerInit = ({
+  cwd,
+  interactive,
+  stdio,
+}): Promise<void> => {
+  return new Promise<void>((resolve, reject) =>
+    exec(
+      `npm init${interactive ? ' -y' : ''}`,
+      { stdio, cwd },
+      (err, stdout, stderr) => (err ? reject(err) : resolve())
+    )
+  );
+};
+
+export const install: PackageManagerInstall = ({
+  cwd,
+  packageName,
+  type,
+  stdio,
+}): Promise<void> => {
+  return new Promise<void>((resolve, reject) => {
+    let installOption = '';
+    switch (type) {
+      case PackageInstallationType.DEV_DEPENDENCIES:
+        installOption = '-D';
+        break;
+      case PackageInstallationType.OPTIONAL:
+        installOption = '-O';
+        break;
+      case PackageInstallationType.BUNDLED:
+        installOption = '-B';
+        break;
+      default:
+        break;
+    }
+    exec(
+      `npm install ${packageName}${installOption ? ` ${installOption}` : ''}`,
+      { stdio, cwd },
+      (err, stdout, stderr) => (err ? reject(err) : resolve())
+    );
+  });
+};

--- a/src/package_managers/npm.ts
+++ b/src/package_managers/npm.ts
@@ -1,5 +1,5 @@
-import { exec } from 'child_process';
-import {
+import { execSync } from 'child_process';
+import BasePackageManager, {
   PackageInstallationType,
   PackageManagerInit,
   PackageManagerInstall,
@@ -9,14 +9,8 @@ export const init: PackageManagerInit = ({
   cwd,
   interactive,
   stdio,
-}): Promise<void> => {
-  return new Promise<void>((resolve, reject) =>
-    exec(
-      `npm init${interactive ? ' -y' : ''}`,
-      { stdio, cwd },
-      (err, stdout, stderr) => (err ? reject(err) : resolve())
-    )
-  );
+}): Buffer => {
+  return execSync(`npm init${interactive ? '' : ' -y'}`, { stdio, cwd });
 };
 
 export const install: PackageManagerInstall = ({
@@ -24,26 +18,26 @@ export const install: PackageManagerInstall = ({
   packageName,
   type,
   stdio,
-}): Promise<void> => {
-  return new Promise<void>((resolve, reject) => {
-    let installOption = '';
-    switch (type) {
-      case PackageInstallationType.DEV_DEPENDENCIES:
-        installOption = '-D';
-        break;
-      case PackageInstallationType.OPTIONAL:
-        installOption = '-O';
-        break;
-      case PackageInstallationType.BUNDLED:
-        installOption = '-B';
-        break;
-      default:
-        break;
-    }
-    exec(
-      `npm install ${packageName}${installOption ? ` ${installOption}` : ''}`,
-      { stdio, cwd },
-      (err, stdout, stderr) => (err ? reject(err) : resolve())
-    );
-  });
+}): Buffer => {
+  let installOption = '';
+  switch (type) {
+    case PackageInstallationType.DEV_DEPENDENCIES:
+      installOption = '-D';
+      break;
+    case PackageInstallationType.OPTIONAL:
+      installOption = '-O';
+      break;
+    default:
+      break;
+  }
+  return execSync(
+    `npm install ${packageName}${installOption ? ` ${installOption}` : ''}`,
+    { stdio, cwd }
+  );
 };
+
+export default {
+  type: 'npm',
+  init,
+  install,
+} as BasePackageManager;

--- a/src/package_managers/package_manager_type.ts
+++ b/src/package_managers/package_manager_type.ts
@@ -1,0 +1,1 @@
+export type PackageManagerType = 'npm' | 'yarn';

--- a/src/package_managers/yarn.ts
+++ b/src/package_managers/yarn.ts
@@ -1,0 +1,43 @@
+import { execSync } from 'child_process';
+import BasePackageManager, {
+  PackageInstallationType,
+  PackageManagerInit,
+  PackageManagerInstall,
+} from './base';
+
+export const init: PackageManagerInit = ({
+  cwd,
+  interactive,
+  stdio,
+}): Buffer => {
+  return execSync(`yarn init${interactive ? '' : ' -y'}`, { stdio, cwd });
+};
+
+export const install: PackageManagerInstall = ({
+  cwd,
+  packageName,
+  type,
+  stdio,
+}): Buffer => {
+  let installOption = '';
+  switch (type) {
+    case PackageInstallationType.DEV_DEPENDENCIES:
+      installOption = '-D';
+      break;
+    case PackageInstallationType.OPTIONAL:
+      installOption = '-O';
+      break;
+    default:
+      break;
+  }
+  return execSync(
+    `yarn add ${packageName}${installOption ? ` ${installOption}` : ''}`,
+    { stdio, cwd }
+  );
+};
+
+export default {
+  type: 'yarn',
+  init,
+  install,
+} as BasePackageManager;


### PR DESCRIPTION
This abstraction is meant to reduce code duplication and increase code simplicity.
Also, I use `cwd` (_current working directory_) to reduce the redundant `cd <project folder>`.

I'm also thinking of maybe changing from static methods in classes to functions cause all of your classes functions are static which provide no benefit of using class